### PR TITLE
Fixes "instance variable @engine not initialized" warning

### DIFF
--- a/lib/simple_router.rb
+++ b/lib/simple_router.rb
@@ -1,7 +1,7 @@
 module SimpleRouter
   class << self
     attr_accessor :engine
-    def engine() @engine || Engines::SimpleEngine end
+    def engine() super || Engines::SimpleEngine end
   end
 
   autoload :DSL,    'simple_router/dsl'


### PR DESCRIPTION
Running with rack::test under rspec on ruby 2.2 I got:
"simple_router-0.9.8.1/lib/simple_router.rb:4: warning: instance variable
@engine not initialized" once for every example that called my app.

As far as I can tell this fix is equivilent in functionality but does not raise
the warning since the instance variable is never manipulated directly ...
