### PR TITLE
Fixes warnings in verbose mode.

### DIFF
--- a/lib/simple_router.rb
+++ b/lib/simple_router.rb
@@ -1,7 +1,8 @@
 module SimpleRouter
   class << self
-    attr_accessor :engine
-    def engine() @engine || Engines::SimpleEngine end
+    attr_accessor :engine_reference
+    def engine() self.engine_reference || Engines::SimpleEngine end
+    def engine=(value) self.engine_reference=value end
   end
 
   autoload :DSL,    'simple_router/dsl'

--- a/lib/simple_router/routes.rb
+++ b/lib/simple_router/routes.rb
@@ -16,9 +16,9 @@ module SimpleRouter
       path, values = SimpleRouter.engine.match(path, paths)
       return nil if path.nil?
 
-      route = routes.detect {|route| route.path == path }
-      route.values = values
-      route
+      final_route = routes.detect {|route| route.path == path }
+      final_route.values = values
+      final_route
     end
 
     class Route


### PR DESCRIPTION
Fixes "Instance variable not defined", "shadowing outer local variable" and
"assigned but unused variable" warnings when using simple_router with rspec and
petty mode turned on.

The reason for wanting these warnings gone in verbose mode is that they get
mixed in with the warnings from the application under test and make it hard to
see what warnings are from the application and what comes from included
libraries.

This isn't an essential patch, it doesn't fix an error. But it would be nice to
have :)
